### PR TITLE
Fix prices timescale for aggregation

### DIFF
--- a/src/utils/fetchAveragePrice.js
+++ b/src/utils/fetchAveragePrice.js
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch'
 
 const fetchAveragePrice = async (itemID, marketSource, quality = 1) => {
-  const apiUrl = `https://www.albion-online-data.com/api/v2/stats/history/${itemID}?locations=${marketSource}&time-scale=1&qualities=${quality}`
+  const apiUrl = `https://www.albion-online-data.com/api/v2/stats/history/${itemID}?locations=${marketSource}&time-scale=24&qualities=${quality}`
   const result = await fetch(apiUrl).then(res => res.json())
   let averagePrice = 0
 


### PR DESCRIPTION
#### :notebook: Overview

- now using `time-scale=24` in albion data API calls to get aggregated prices, which hopefully should better represent the actual price